### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ os:
   - osx
 sudo: required
 julia:
-  - release
-    #  - nightly
+  - 0.4
+  - 0.5
+  - nightly
 notifications:
   email: false
 after_success:

--- a/src/QuantumLab.jl
+++ b/src/QuantumLab.jl
@@ -1,6 +1,6 @@
 module QuantumLab
 
-lib_path = joinpath(Pkg.dir("QuantumLab"),"deps","usr","lib")
+lib_path = joinpath(dirname(@__FILE__),"..","deps","usr","lib")
 push!(Libdl.DL_LOAD_PATH,lib_path)
 Libdl.dlopen("libint2-alpha.so.2")
 


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent RC now, release once final tags are done
