### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ sudo: required
 git:
   depth: 3 
 julia:
-  - release
-  - nightly
   - 0.5
+  - 0.6
+  - nightly
 matrix:
   allow_failures:
     - julia: nightly


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.5 so it should continue to be tested